### PR TITLE
chore(deps): upgrade projen to version 0.91.25

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
         with:
-          app_id: ${{ secrets.PROJEN_APP_ID }}
-          private_key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
         with:
-          app_id: ${{ secrets.PROJEN_APP_ID }}
-          private_key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -45,10 +45,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
         with:
-          app_id: ${{ secrets.PROJEN_APP_ID }}
-          private_key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -97,7 +97,7 @@
     },
     {
       "name": "projen",
-      "version": "^0.91.20",
+      "version": "^0.91.25",
       "type": "peer"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -11,11 +11,11 @@ const project = new cdk.JsiiProject({
   packageManager: javascript.NodePackageManager.NPM,
   defaultReleaseBranch: 'main',
   peerDeps: [
-    'projen@^0.91.20',
+    'projen@^0.91.25',
     'constructs@^10.4.2',
   ],
   devDeps: [
-    'projen@0.91.20',
+    'projen@0.91.25',
     'constructs@10.4.2',
   ],
   license: 'Apache-2.0',

--- a/API.md
+++ b/API.md
@@ -9550,6 +9550,7 @@ const privateTaimosCdkAppOptions: PrivateTaimosCdkAppOptions = { ... }
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.cdkTestDependencies">cdkTestDependencies</a></code> | <code>string[]</code> | AWS CDK modules required for testing. |
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.cdkVersionPinning">cdkVersionPinning</a></code> | <code>boolean</code> | Use pinned version instead of caret version for CDK. |
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.constructsVersion">constructsVersion</a></code> | <code>string</code> | Minimum version of the `constructs` library to depend on. |
+| <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.app">app</a></code> | <code>string</code> | The command line to execute in order to synthesize the CDK application (language specific). |
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.appEntrypoint">appEntrypoint</a></code> | <code>string</code> | The CDK app's entrypoint (relative to the source directory, which is "src" by default). |
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.edgeLambdaAutoDiscover">edgeLambdaAutoDiscover</a></code> | <code>boolean</code> | Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. |
 | <code><a href="#@taimos/projen.PrivateTaimosCdkAppOptions.property.experimentalIntegRunner">experimentalIntegRunner</a></code> | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner. |
@@ -10644,6 +10645,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -11931,6 +11933,18 @@ Minimum version of the `constructs` library to depend on.
 
 ---
 
+##### `app`<sup>Optional</sup> <a name="app" id="@taimos/projen.PrivateTaimosCdkAppOptions.property.app"></a>
+
+```typescript
+public readonly app: string;
+```
+
+- *Type:* string
+
+The command line to execute in order to synthesize the CDK application (language specific).
+
+---
+
 ##### `appEntrypoint`<sup>Optional</sup> <a name="appEntrypoint" id="@taimos/projen.PrivateTaimosCdkAppOptions.property.appEntrypoint"></a>
 
 ```typescript
@@ -12200,6 +12214,7 @@ const productionTaimosCdkAppOptions: ProductionTaimosCdkAppOptions = { ... }
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.cdkTestDependencies">cdkTestDependencies</a></code> | <code>string[]</code> | AWS CDK modules required for testing. |
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.cdkVersionPinning">cdkVersionPinning</a></code> | <code>boolean</code> | Use pinned version instead of caret version for CDK. |
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.constructsVersion">constructsVersion</a></code> | <code>string</code> | Minimum version of the `constructs` library to depend on. |
+| <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.app">app</a></code> | <code>string</code> | The command line to execute in order to synthesize the CDK application (language specific). |
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.appEntrypoint">appEntrypoint</a></code> | <code>string</code> | The CDK app's entrypoint (relative to the source directory, which is "src" by default). |
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.edgeLambdaAutoDiscover">edgeLambdaAutoDiscover</a></code> | <code>boolean</code> | Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. |
 | <code><a href="#@taimos/projen.ProductionTaimosCdkAppOptions.property.experimentalIntegRunner">experimentalIntegRunner</a></code> | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner. |
@@ -13298,6 +13313,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -14585,6 +14601,18 @@ Minimum version of the `constructs` library to depend on.
 
 ---
 
+##### `app`<sup>Optional</sup> <a name="app" id="@taimos/projen.ProductionTaimosCdkAppOptions.property.app"></a>
+
+```typescript
+public readonly app: string;
+```
+
+- *Type:* string
+
+The command line to execute in order to synthesize the CDK application (language specific).
+
+---
+
 ##### `appEntrypoint`<sup>Optional</sup> <a name="appEntrypoint" id="@taimos/projen.ProductionTaimosCdkAppOptions.property.appEntrypoint"></a>
 
 ```typescript
@@ -14948,6 +14976,7 @@ const taimosCdkAppOptions: TaimosCdkAppOptions = { ... }
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.cdkTestDependencies">cdkTestDependencies</a></code> | <code>string[]</code> | AWS CDK modules required for testing. |
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.cdkVersionPinning">cdkVersionPinning</a></code> | <code>boolean</code> | Use pinned version instead of caret version for CDK. |
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.constructsVersion">constructsVersion</a></code> | <code>string</code> | Minimum version of the `constructs` library to depend on. |
+| <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.app">app</a></code> | <code>string</code> | The command line to execute in order to synthesize the CDK application (language specific). |
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.appEntrypoint">appEntrypoint</a></code> | <code>string</code> | The CDK app's entrypoint (relative to the source directory, which is "src" by default). |
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.edgeLambdaAutoDiscover">edgeLambdaAutoDiscover</a></code> | <code>boolean</code> | Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. |
 | <code><a href="#@taimos/projen.TaimosCdkAppOptions.property.experimentalIntegRunner">experimentalIntegRunner</a></code> | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner. |
@@ -16042,6 +16071,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -17326,6 +17356,18 @@ public readonly constructsVersion: string;
 - *Default:* for CDK 1.x the default is "3.2.27", for CDK 2.x the default is "10.0.5".
 
 Minimum version of the `constructs` library to depend on.
+
+---
+
+##### `app`<sup>Optional</sup> <a name="app" id="@taimos/projen.TaimosCdkAppOptions.property.app"></a>
+
+```typescript
+public readonly app: string;
+```
+
+- *Type:* string
+
+The command line to execute in order to synthesize the CDK application (language specific).
 
 ---
 
@@ -18701,6 +18743,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -21463,6 +21506,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -23762,6 +23806,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,13 +26,13 @@
         "jsii-docgen": "^10.5.0",
         "jsii-pacmak": "^1.111.0",
         "jsii-rosetta": "~5.6.0",
-        "projen": "0.91.20",
+        "projen": "0.91.25",
         "ts-jest": "^29",
         "typescript": "^5.5.4"
       },
       "peerDependencies": {
         "constructs": "^10.4.2",
-        "projen": "^0.91.20"
+        "projen": "^0.91.25"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -10453,9 +10453,9 @@
       "license": "MIT"
     },
     "node_modules/projen": {
-      "version": "0.91.20",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.91.20.tgz",
-      "integrity": "sha512-CurufZ0DMMpP7w5tlm7e5MvoSUEFL2tCpPqRFVc+G74E8Z8+CnnFpwxz8OUhQrbOtn7GyNkfhR6o+UNTcstpig==",
+      "version": "0.91.25",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.91.25.tgz",
+      "integrity": "sha512-QMDg4zHRdVkf5yvpxtiRFsCWlDaJ1x2WK/tZgeU+DAYAa/YKbsIK/xMQ5qmDzbLhTyulqPMjB2BHDA68lrjhkw==",
       "bundleDependencies": [
         "@iarna/toml",
         "case",

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.111.0",
     "jsii-rosetta": "~5.6.0",
-    "projen": "0.91.20",
+    "projen": "0.91.25",
     "ts-jest": "^29",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
     "constructs": "^10.4.2",
-    "projen": "^0.91.20"
+    "projen": "^0.91.25"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -8,7 +8,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2019"
+      "es2020"
     ],
     "module": "CommonJS",
     "noEmitOnError": false,
@@ -23,7 +23,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2019"
+    "target": "ES2020"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
- Updated projen dependency from 0.91.20 to 0.91.25 in package.json, package-lock.json, and .projenrc.js.
- Changed TypeScript target and lib in tsconfig.dev.json from ES2019 to ES2020.
- Updated GitHub Actions workflows to use the latest token generation action.

Fixes #