### PR TITLE
feat(monorepo): only trigger build workflow on package changes

### DIFF
--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -337,10 +337,15 @@ export class MonorepoProject extends typescript.TypeScriptProject {
     if (options.runTestsInBuild ?? true) {
       buildSteps.push({ name: 'Test', run: 'pnpm -r run test' });
     }
+    // Path filter: only trigger builds when workspace package files change.
+    // Changes to specs or docs alone should not trigger a new build.
+    const workspacePackages = ws.packages ?? ['packages/*'];
+    const buildPaths = workspacePackages.map((pkg) => `${pkg}/**`);
+
     this.prBuildWorkflow = new github.GithubWorkflow(this.github!, 'build');
     this.prBuildWorkflow.on({
-      pullRequest: {},
-      push: { branches: ['main'] },
+      pullRequest: { paths: buildPaths },
+      push: { branches: ['main'], paths: buildPaths },
       workflowDispatch: {},
     });
     this.prBuildWorkflow.addJob('build', {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Adds path filters to the monorepo's unified PR build workflow so it only triggers when files inside the workspace packages directory change.

## Changes

- Added `paths` filter to both `pull_request` and `push` triggers in the build workflow
- Paths are derived from the workspace `packages` configuration (defaults to `packages/**`)
- `workflowDispatch` remains unfiltered so manual builds are always possible

## Effect

- Changes to specs, docs, or other non-package files will **no longer** trigger the build workflow
- Only changes under the configured workspace package paths (e.g. `packages/**`) trigger builds
- This saves CI minutes and reduces noise on documentation/spec-only PRs