### PR TITLE
feat(monorepo): include root config files in build path triggers

### DIFF
--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -337,10 +337,30 @@ export class MonorepoProject extends typescript.TypeScriptProject {
     if (options.runTestsInBuild ?? true) {
       buildSteps.push({ name: 'Test', run: 'pnpm -r run test' });
     }
-    // Path filter: only trigger builds when workspace package files change.
-    // Changes to specs or docs alone should not trigger a new build.
+    // Path filter: only trigger builds when workspace package files or
+    // build-relevant root configuration changes. Changes to specs or docs
+    // alone should not trigger a new build.
     const workspacePackages = ws.packages ?? ['packages/*'];
-    const buildPaths = workspacePackages.map((pkg) => `${pkg}/**`);
+    const buildPaths: string[] = [
+      // Workspace package source files.
+      ...workspacePackages.map((pkg) => `${pkg}/**`),
+      // Dependency lock & workspace configuration.
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      // Root package.json (scripts, devDeps, engines).
+      'package.json',
+      // Projen configuration — regenerates project files.
+      '.projenrc.ts',
+      '.projenrc.js',
+      // Shared TypeScript configuration.
+      'tsconfig.json',
+      'tsconfig.*.json',
+      // The build workflow itself.
+      '.github/workflows/build.yml',
+      // Shared lint configuration.
+      '.eslintrc.*',
+      'eslint.config.*',
+    ];
 
     this.prBuildWorkflow = new github.GithubWorkflow(this.github!, 'build');
     this.prBuildWorkflow.on({


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Expands the build workflow path triggers to also include root configuration files that affect builds.

## Added paths

| Path | Reason |
|------|--------|
| `pnpm-lock.yaml` | Dependency changes |
| `pnpm-workspace.yaml` | Workspace configuration |
| `package.json` | Root scripts, devDeps, engines |
| `.projenrc.ts` / `.projenrc.js` | Projen config regeneration |
| `tsconfig.json` / `tsconfig.*.json` | Shared TypeScript settings |
| `.github/workflows/build.yml` | The workflow itself |
| `.eslintrc.*` / `eslint.config.*` | Shared lint configuration |

These complement the existing `packages/**` trigger from #364 so that dependency, TypeScript, lint, and project configuration changes also trigger CI.

Changes to specs, docs, README, or other files outside these paths still do **not** trigger a build.