### PR TITLE
feat: include .projen/** in monorepo build workflow path filters

### DIFF
--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -352,6 +352,7 @@ export class MonorepoProject extends typescript.TypeScriptProject {
       // Projen configuration — regenerates project files.
       '.projenrc.ts',
       '.projenrc.js',
+      '.projen/**',
       // Shared TypeScript configuration.
       'tsconfig.json',
       'tsconfig.*.json',


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Adds `.projen/**` to the `buildPaths` array in the `MonorepoProject` construct so that the generated `build.yml` workflow's `pull_request.paths` and `push.paths` filters include projen generator source files.

## Problem

Changes to `.projen/` sources (e.g. `monorepo.ts` and other generator modules that split up `.projenrc.ts`) regenerate project configuration but were not triggering CI because `.projen/**` was missing from the path filters.

## Changes

- Added `'.projen/**'` to the `buildPaths` array in `src/projects/monorepo.ts`, alongside the existing `.projenrc.ts` and `.projenrc.js` entries.

## Testing

- Verified the project compiles cleanly with `tsc --noEmit`.