### PR TITLE
fix: scope Amplify preBuild install per app (#372)

### DIFF
--- a/API.md
+++ b/API.md
@@ -10248,6 +10248,8 @@ const monorepoAmplifyApp: MonorepoAmplifyApp = { ... }
 | <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.artifactBaseDirectory">artifactBaseDirectory</a></code> | <code>string</code> | Override the artifact base directory. |
 | <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.buildCommand">buildCommand</a></code> | <code>string</code> | Override the build command run in the Amplify `build` phase. |
 | <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.cachePaths">cachePaths</a></code> | <code>string[]</code> | Override the Amplify build cache paths. |
+| <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.installCommand">installCommand</a></code> | <code>string</code> | Full override of the install command in the preBuild phase. |
+| <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.installFilter">installFilter</a></code> | <code>string</code> | pnpm `--filter` expression for the scoped install in the preBuild phase. |
 | <code><a href="#@taimos/projen.MonorepoAmplifyApp.property.preBuildFilters">preBuildFilters</a></code> | <code>string[]</code> | Workspace packages to build before the app, as `--filter` targets. |
 
 ---
@@ -10324,6 +10326,40 @@ public readonly cachePaths: string[];
 - *Default:* `node_modules/**` plus the framework build cache (`<appRoot>/.next/cache/**` or `<appRoot>/.angular/cache/**`).
 
 Override the Amplify build cache paths.
+
+---
+
+##### `installCommand`<sup>Optional</sup> <a name="installCommand" id="@taimos/projen.MonorepoAmplifyApp.property.installCommand"></a>
+
+```typescript
+public readonly installCommand: string;
+```
+
+- *Type:* string
+- *Default:* `pnpm install --frozen-lockfile --node-linker hoisted --filter "<installFilter>"`
+
+Full override of the install command in the preBuild phase.
+
+When set, `installFilter` is ignored and this string is emitted verbatim.
+Use this as an escape hatch when the default scoped install is insufficient.
+
+---
+
+##### `installFilter`<sup>Optional</sup> <a name="installFilter" id="@taimos/projen.MonorepoAmplifyApp.property.installFilter"></a>
+
+```typescript
+public readonly installFilter: string;
+```
+
+- *Type:* string
+- *Default:* `${buildFilter}...`
+
+pnpm `--filter` expression for the scoped install in the preBuild phase.
+
+The trailing `...` syntax pulls in the app's transitive workspace
+dependencies (e.g. a shared API package) but excludes unrelated packages,
+avoiding concurrent `projen/node_modules` rename races under the hoisted
+linker.
 
 ---
 

--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -73,6 +73,28 @@ export interface MonorepoAmplifyApp {
    * (`<appRoot>/.next/cache/**` or `<appRoot>/.angular/cache/**`).
    */
   readonly cachePaths?: string[];
+
+  /**
+   * pnpm `--filter` expression for the scoped install in the preBuild phase.
+   *
+   * The trailing `...` syntax pulls in the app's transitive workspace
+   * dependencies (e.g. a shared API package) but excludes unrelated packages,
+   * avoiding concurrent `projen/node_modules` rename races under the hoisted
+   * linker.
+   *
+   * @default `${buildFilter}...`
+   */
+  readonly installFilter?: string;
+
+  /**
+   * Full override of the install command in the preBuild phase.
+   *
+   * When set, `installFilter` is ignored and this string is emitted verbatim.
+   * Use this as an escape hatch when the default scoped install is insufficient.
+   *
+   * @default - `pnpm install --frozen-lockfile --node-linker hoisted --filter "<installFilter>"`
+   */
+  readonly installCommand?: string;
 }
 
 /**
@@ -420,11 +442,14 @@ export class MonorepoProject extends typescript.TypeScriptProject {
 
   private renderAmplifyApp(app: MonorepoAmplifyApp) {
     const angular = app.framework === MonorepoAmplifyFramework.ANGULAR;
+    // Scope the install to the app's dependency closure to avoid concurrent
+    // projen/node_modules rename races under the hoisted linker (see #372).
+    const filter = app.installFilter ?? `${app.buildFilter}...`;
+    const installCommand = app.installCommand
+      ?? `pnpm install --frozen-lockfile --node-linker hoisted --filter "${filter}"`;
     const preBuild = [
       'corepack enable',
-      // Force pnpm's hoisted linker for the Amplify build only — Amplify's
-      // managed compute traces runtime deps from a flat node_modules.
-      'pnpm install --frozen-lockfile --node-linker hoisted',
+      installCommand,
       ...(app.preBuildFilters ?? []).map((f) => `pnpm --filter ${f} run build`),
     ];
     // BUILD_ENV (dev|prod) is provided as an Amplify environment variable.

--- a/test/monorepo-amplify.test.ts
+++ b/test/monorepo-amplify.test.ts
@@ -1,0 +1,165 @@
+import { Testing } from 'projen';
+import * as yaml from 'yaml';
+import { MonorepoAmplifyFramework, MonorepoProject, MonorepoProjectOptions } from '../src';
+
+function synthMonorepo(opts: Partial<MonorepoProjectOptions> = {}) {
+  const project = new MonorepoProject({
+    name: 'test-monorepo',
+    defaultReleaseBranch: 'main',
+    ...opts,
+  });
+  return Testing.synth(project) as Record<string, any>;
+}
+
+function getAmplifyYml(opts: Partial<MonorepoProjectOptions> = {}) {
+  const out = synthMonorepo(opts);
+  return yaml.parse(out['amplify.yml']);
+}
+
+describe('MonorepoProject amplify.yml scoped install', () => {
+  test('default install uses --filter with buildFilter and trailing ...', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuild).toContain(
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "web-app..."',
+    );
+  });
+
+  test('no unfiltered full-workspace install is generated', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    // Must not contain an unscoped install
+    const unscopedInstall = preBuild.find(
+      (cmd: string) => cmd.includes('pnpm install') && !cmd.includes('--filter'),
+    );
+    expect(unscopedInstall).toBeUndefined();
+  });
+
+  test('installFilter overrides the default filter expression', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+        installFilter: '{web-app,shared-api}...',
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuild).toContain(
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "{web-app,shared-api}..."',
+    );
+  });
+
+  test('installCommand fully overrides the install step', () => {
+    const customInstall = 'npm ci --legacy-peer-deps';
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+        installCommand: customInstall,
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuild).toContain(customInstall);
+    // The default pnpm install must not appear
+    expect(preBuild.find((cmd: string) => cmd.includes('pnpm install'))).toBeUndefined();
+  });
+
+  test('installCommand takes precedence over installFilter', () => {
+    const customInstall = 'yarn install --frozen-lockfile';
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+        installFilter: 'should-be-ignored...',
+        installCommand: customInstall,
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuild).toContain(customInstall);
+    expect(preBuild.find((cmd: string) => cmd.includes('should-be-ignored'))).toBeUndefined();
+  });
+
+  test('preBuildFilters are preserved after the scoped install', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/frontend',
+        framework: MonorepoAmplifyFramework.NEXTJS,
+        buildFilter: 'web-app',
+        preBuildFilters: ['@taimos/shared-api'],
+      }],
+    });
+
+    const preBuild = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuild).toEqual([
+      'corepack enable',
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "web-app..."',
+      'pnpm --filter @taimos/shared-api run build',
+    ]);
+  });
+
+  test('Angular app gets scoped install with correct build command', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [{
+        appRoot: 'packages/portal',
+        framework: MonorepoAmplifyFramework.ANGULAR,
+        buildFilter: 'portal-app',
+      }],
+    });
+
+    const app = amplify.applications[0];
+    const preBuild = app.frontend.phases.preBuild.commands;
+    expect(preBuild).toContain(
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "portal-app..."',
+    );
+    expect(app.frontend.phases.build.commands[0]).toBe(
+      'pnpm --filter portal-app run build:${BUILD_ENV}',
+    );
+  });
+
+  test('multiple apps each get their own scoped install', () => {
+    const amplify = getAmplifyYml({
+      amplifyApps: [
+        {
+          appRoot: 'packages/app-a',
+          framework: MonorepoAmplifyFramework.NEXTJS,
+          buildFilter: 'app-a',
+        },
+        {
+          appRoot: 'packages/app-b',
+          framework: MonorepoAmplifyFramework.ANGULAR,
+          buildFilter: 'app-b',
+        },
+      ],
+    });
+
+    const preBuildA = amplify.applications[0].frontend.phases.preBuild.commands;
+    expect(preBuildA).toContain(
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "app-a..."',
+    );
+
+    const preBuildB = amplify.applications[1].frontend.phases.preBuild.commands;
+    expect(preBuildB).toContain(
+      'pnpm install --frozen-lockfile --node-linker hoisted --filter "app-b..."',
+    );
+  });
+});


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Scopes the generated `amplify.yml` preBuild install to the app's dependency closure instead of a full-workspace install, fixing the intermittent `ERR_PNPM_EEXIST` race when multiple workspace packages declare `projen` as a devDependency.

## Changes

- Default install is now:
  ```
  pnpm install --frozen-lockfile --node-linker hoisted --filter "<buildFilter>..."
  ```
- Added `installFilter` prop — override the `--filter` expression (default: `${buildFilter}...`)
- Added `installCommand` prop — full override of the install command (escape hatch)
- `preBuildFilters`, `buildCommand`, `artifactBaseDirectory`, and `cachePaths` behavior unchanged

## Testing

- 8 new unit tests covering default scoped install, `installFilter` override, `installCommand` override, precedence rules, Angular framework, and multi-app scenarios
- Full test suite passes (14 tests, 3 suites)
- TypeScript compiles cleanly

Closes #372