### PR TITLE
fix: emit allowBuilds so pnpm 11 runs approved install scripts

### DIFF
--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -303,6 +303,12 @@ export class MonorepoProject extends typescript.TypeScriptProject {
       pnpmOptions: {
         ...options.pnpmOptions,
         workspaceYamlOptions: {
+          // pnpm 11 replaced `onlyBuiltDependencies` (which `allowScripts`
+          // renders) with `allowBuilds`, and reads only the latter — a pnpm 11
+          // install otherwise aborts with ERR_PNPM_IGNORED_BUILDS. pnpm 10 reads
+          // only `onlyBuiltDependencies`. Emit both so the same workspace file
+          // works on either, whatever `pnpmVersion` a consumer pins.
+          allowBuilds: Object.fromEntries(allowedBuilds.map((pkg) => [pkg, true])),
           packages: ws.packages ?? ['packages/*'],
           minimumReleaseAge: ws.minimumReleaseAge ?? 2880, // 2 days in minutes
           minimumReleaseAgeExclude: ws.minimumReleaseAgeExclude ?? [

--- a/test/monorepo-workspace.test.ts
+++ b/test/monorepo-workspace.test.ts
@@ -24,6 +24,13 @@ describe('MonorepoProject pnpm-workspace.yaml (native projen component)', () => 
       'sharp',
       'unrs-resolver',
     ]);
+    // ...and mirrored into `allowBuilds`, the key pnpm 11 reads instead.
+    expect(ws.allowBuilds).toEqual({
+      '@aws-amplify/cli': true,
+      'esbuild': true,
+      'sharp': true,
+      'unrs-resolver': true,
+    });
     expect(ws.minimumReleaseAge).toBe(2880);
     expect(ws.minimumReleaseAgeExclude).toEqual([
       'projen-pipelines',
@@ -48,8 +55,20 @@ describe('MonorepoProject pnpm-workspace.yaml (native projen component)', () => 
     expect(ws.packages).toEqual(['packages/*', 'apps/*']);
     expect(ws.overrides).toEqual({ 'left-pad': '1.3.0' });
     expect(ws.onlyBuiltDependencies).toEqual(['esbuild', 'sharp']);
+    expect(ws.allowBuilds).toEqual({ esbuild: true, sharp: true });
     expect(ws.minimumReleaseAge).toBe(60);
     expect(ws.minimumReleaseAgeExclude).toEqual(['@taimos/projen']);
+  });
+
+  test('lets consumer pnpmOptions win over the defaults', () => {
+    const ws = getWorkspaceYaml({
+      workspaceOptions: { allowedBuilds: ['esbuild'] },
+      pnpmOptions: {
+        workspaceYamlOptions: { allowBuilds: { 'esbuild': true, 'better-sqlite3': true } },
+      },
+    });
+
+    expect(ws.allowBuilds).toEqual({ 'esbuild': true, 'better-sqlite3': true });
   });
 
   test('exposes the generated file via workspaceFile', () => {


### PR DESCRIPTION
## Problem

Since 0.1.75 moved `MonorepoProject` onto projen's native `pnpm-workspace.yaml` component, the build allowlist reaches the file only as `onlyBuiltDependencies` (rendered from `allowScripts`). pnpm 11 replaced that setting with `allowBuilds` and reads **only** the new one, so the first install in a consumer repo on pnpm 11 fails:

```
ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: @aws-amplify/cli, @parcel/watcher,
esbuild, lmdb, msgpackr-extract, sharp, unrs-resolver
```

pnpm 10 — the `pnpmVersion` default, and what CI and Amplify Hosting run via `corepack enable` — reads only `onlyBuiltDependencies`, so neither key alone covers both. Before 0.1.75 the hand-rolled YAML emitted both, and the `allowedBuilds` docstring still promises exactly that ("populates both `allowBuilds` and `onlyBuiltDependencies`").

Found while upgrading `radball-digital` to 0.1.75, which needed a local `pnpmOptions.workspaceYamlOptions.allowBuilds` workaround to install at all.

## Change

Render `allowedBuilds` into `allowBuilds` as well, as a `{ [pkg]: true }` map. It sits ahead of the consumer spread, so `pnpmOptions.workspaceYamlOptions.allowBuilds` still wins.

## Tests

`test/monorepo-workspace.test.ts` — `allowBuilds` asserted for the defaults and for a custom `allowedBuilds` list, plus a new case covering the consumer override. 18 tests pass; `npx projen build` (jsii compile, docgen, eslint, pacmak) is green.