### PR TITLE
feat: add GitHubAmplifyDeploy for path-scoped Amplify builds

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,322 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
+### GitHubAmplifyDeploy <a name="GitHubAmplifyDeploy" id="@taimos/projen.GitHubAmplifyDeploy"></a>
+
+Adds one path-scoped deploy workflow per Amplify Hosting app.
+
+Amplify's own auto-build fires on every push to a tracked branch. In a
+monorepo that means every frontend rebuilds whenever anything changes — the
+marketing site rebuilding for a backend-only commit and vice versa, once per
+tracked branch. Amplify bills build minutes, so most of those are waste.
+
+Amplify's native answer, `AMPLIFY_DIFF_DEPLOY`, diffs exactly one directory
+(`AMPLIFY_MONOREPO_APP_ROOT`, overridable via `AMPLIFY_DIFF_DEPLOY_ROOT` —
+still a single path). That is enough for a self-contained app but not for one
+that also depends on a shared workspace package: a one-directory diff would
+ship a stale frontend whenever the shared types changed. GitHub's `paths:`
+filters accept multiple globs, so builds move to CI.
+
+Each generated workflow resolves the pushed branch to its stage and account,
+chains OIDC -> deployment role -> build-trigger role, reads the app id from
+SSM, starts a `RELEASE` job and polls until it reaches a terminal state — so
+a failed Amplify build fails the workflow instead of passing silently.
+
+This component generates the CI half only. The infrastructure half belongs in
+the project's own CDK app, which must:
+
+  1. set `autoBuild: false` on every branch these workflows build,
+  2. publish each app's id to `<parameterPrefix>/<key>/app-id`, and
+  3. create a role named `buildTriggerRoleName` in each stage account,
+     trusted by `deploymentRoleArn` and granting `amplify:StartJob` +
+     `amplify:GetJob` on the tracked branch ARNs only.
+
+Use `buildTriggerRoleName` and `appIdParameterName()` from the projenrc to
+keep those names in step; a mismatch fails the workflow loudly at the
+assume-role or parameter-read step rather than skipping a deploy.
+
+#### Initializers <a name="Initializers" id="@taimos/projen.GitHubAmplifyDeploy.Initializer"></a>
+
+```typescript
+import { GitHubAmplifyDeploy } from '@taimos/projen'
+
+new GitHubAmplifyDeploy(scope: GitHubProject, options: GitHubAmplifyDeployOptions)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.Initializer.parameter.scope">scope</a></code> | <code>projen.github.GitHubProject</code> | *No description.* |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.Initializer.parameter.options">options</a></code> | <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions">GitHubAmplifyDeployOptions</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@taimos/projen.GitHubAmplifyDeploy.Initializer.parameter.scope"></a>
+
+- *Type:* projen.github.GitHubProject
+
+---
+
+##### `options`<sup>Required</sup> <a name="options" id="@taimos/projen.GitHubAmplifyDeploy.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#@taimos/projen.GitHubAmplifyDeployOptions">GitHubAmplifyDeployOptions</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.with">with</a></code> | Applies one or more mixins to this construct. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.postProjectCreation">postProjectCreation</a></code> | Called once, right after `postSynthesize()`, only when the project is created for the first time. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.projectCreation">projectCreation</a></code> | Called once, right after `synthesize()`, only when the project is created for the first time. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.appIdParameterName">appIdParameterName</a></code> | The SSM parameter path holding an app's Amplify app id. |
+
+---
+
+##### `toString` <a name="toString" id="@taimos/projen.GitHubAmplifyDeploy.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `with` <a name="with" id="@taimos/projen.GitHubAmplifyDeploy.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="@taimos/projen.GitHubAmplifyDeploy.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
+
+##### `postProjectCreation` <a name="postProjectCreation" id="@taimos/projen.GitHubAmplifyDeploy.postProjectCreation"></a>
+
+```typescript
+public postProjectCreation(initProject: InitProject): void
+```
+
+Called once, right after `postSynthesize()`, only when the project is created for the first time.
+
+It does not run on later `projen` invocations. It only fires for `projen new` (or `Projects.createProject`).
+It is also skipped when post-synthesis steps are disabled, e.g. `--no-post` or `PROJEN_DISABLE_POST`.
+Use it for one-off setup that can be turned off by the user, like running a task to give the user immediate
+feedback on their new project. Order across components is not guaranteed.
+
+###### `initProject`<sup>Required</sup> <a name="initProject" id="@taimos/projen.GitHubAmplifyDeploy.postProjectCreation.parameter.initProject"></a>
+
+- *Type:* projen.InitProject
+
+Details about how the project was created, e.g. its type and the original CLI args.
+
+---
+
+##### `postSynthesize` <a name="postSynthesize" id="@taimos/projen.GitHubAmplifyDeploy.postSynthesize"></a>
+
+```typescript
+public postSynthesize(): void
+```
+
+Called after synthesis.
+
+Order is *not* guaranteed.
+
+##### `preSynthesize` <a name="preSynthesize" id="@taimos/projen.GitHubAmplifyDeploy.preSynthesize"></a>
+
+```typescript
+public preSynthesize(): void
+```
+
+Called before synthesis.
+
+##### `projectCreation` <a name="projectCreation" id="@taimos/projen.GitHubAmplifyDeploy.projectCreation"></a>
+
+```typescript
+public projectCreation(initProject: InitProject): void
+```
+
+Called once, right after `synthesize()`, only when the project is created for the first time.
+
+It does not run on later `projen` invocations. It only fires for `projen new` (or `Projects.createProject`).
+Use it for deterministic, one-off file generation. Order across components is not guaranteed.
+
+###### `initProject`<sup>Required</sup> <a name="initProject" id="@taimos/projen.GitHubAmplifyDeploy.projectCreation.parameter.initProject"></a>
+
+- *Type:* projen.InitProject
+
+Details about how the project was created, e.g. its type and the original CLI args.
+
+---
+
+##### `synthesize` <a name="synthesize" id="@taimos/projen.GitHubAmplifyDeploy.synthesize"></a>
+
+```typescript
+public synthesize(): void
+```
+
+Synthesizes files to the project output directory.
+
+##### `appIdParameterName` <a name="appIdParameterName" id="@taimos/projen.GitHubAmplifyDeploy.appIdParameterName"></a>
+
+```typescript
+public appIdParameterName(key: string): string
+```
+
+The SSM parameter path holding an app's Amplify app id.
+
+The CDK side must
+publish the id under exactly this name.
+
+###### `key`<sup>Required</sup> <a name="key" id="@taimos/projen.GitHubAmplifyDeploy.appIdParameterName.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.isComponent">isComponent</a></code> | Test whether the given construct is a component. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@taimos/projen.GitHubAmplifyDeploy.isConstruct"></a>
+
+```typescript
+import { GitHubAmplifyDeploy } from '@taimos/projen'
+
+GitHubAmplifyDeploy.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@taimos/projen.GitHubAmplifyDeploy.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isComponent` <a name="isComponent" id="@taimos/projen.GitHubAmplifyDeploy.isComponent"></a>
+
+```typescript
+import { GitHubAmplifyDeploy } from '@taimos/projen'
+
+GitHubAmplifyDeploy.isComponent(x: any)
+```
+
+Test whether the given construct is a component.
+
+###### `x`<sup>Required</sup> <a name="x" id="@taimos/projen.GitHubAmplifyDeploy.isComponent.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.property.buildTriggerRoleName">buildTriggerRoleName</a></code> | <code>string</code> | Name of the IAM role CI chains into, in every stage account. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.property.parameterPrefix">parameterPrefix</a></code> | <code>string</code> | Prefix of the SSM parameter path holding each app's Amplify app id. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeploy.property.workflows">workflows</a></code> | <code>projen.github.GithubWorkflow[]</code> | The generated deploy workflows, one per app. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@taimos/projen.GitHubAmplifyDeploy.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="@taimos/projen.GitHubAmplifyDeploy.property.project"></a>
+
+```typescript
+public readonly project: Project;
+```
+
+- *Type:* projen.Project
+
+---
+
+##### `buildTriggerRoleName`<sup>Required</sup> <a name="buildTriggerRoleName" id="@taimos/projen.GitHubAmplifyDeploy.property.buildTriggerRoleName"></a>
+
+```typescript
+public readonly buildTriggerRoleName: string;
+```
+
+- *Type:* string
+
+Name of the IAM role CI chains into, in every stage account.
+
+---
+
+##### `parameterPrefix`<sup>Required</sup> <a name="parameterPrefix" id="@taimos/projen.GitHubAmplifyDeploy.property.parameterPrefix"></a>
+
+```typescript
+public readonly parameterPrefix: string;
+```
+
+- *Type:* string
+
+Prefix of the SSM parameter path holding each app's Amplify app id.
+
+---
+
+##### `workflows`<sup>Required</sup> <a name="workflows" id="@taimos/projen.GitHubAmplifyDeploy.property.workflows"></a>
+
+```typescript
+public readonly workflows: GithubWorkflow[];
+```
+
+- *Type:* projen.github.GithubWorkflow[]
+
+The generated deploy workflows, one per app.
+
+---
+
+
 ### GitHubProductionRelease <a name="GitHubProductionRelease" id="@taimos/projen.GitHubProductionRelease"></a>
 
 Adds a manual "Production Release" workflow that promotes a branch into a production branch.
@@ -921,6 +1237,7 @@ When given a project, this it the project itself.
 | <code><a href="#@taimos/projen.MonorepoProject.property.defaultReleaseBranch">defaultReleaseBranch</a></code> | <code>string</code> | The default release branch (promoted by the production release workflow). |
 | <code><a href="#@taimos/projen.MonorepoProject.property.prBuildWorkflow">prBuildWorkflow</a></code> | <code>projen.github.GithubWorkflow</code> | The unified PR build workflow. |
 | <code><a href="#@taimos/projen.MonorepoProject.property.workspaceFile">workspaceFile</a></code> | <code>projen.YamlFile</code> | The generated `pnpm-workspace.yaml`. |
+| <code><a href="#@taimos/projen.MonorepoProject.property.amplifyDeploy">amplifyDeploy</a></code> | <code><a href="#@taimos/projen.GitHubAmplifyDeploy">GitHubAmplifyDeploy</a></code> | The Amplify deploy workflows, when `amplifyDeployOptions` is set. |
 | <code><a href="#@taimos/projen.MonorepoProject.property.amplifyFile">amplifyFile</a></code> | <code>projen.YamlFile</code> | The generated `amplify.yml`, if any Amplify apps were configured. |
 | <code><a href="#@taimos/projen.MonorepoProject.property.assignApprover">assignApprover</a></code> | <code>projen-pipelines.GitHubAssignApprover</code> | The PR approver assignment, if enabled. |
 | <code><a href="#@taimos/projen.MonorepoProject.property.productionRelease">productionRelease</a></code> | <code><a href="#@taimos/projen.GitHubProductionRelease">GitHubProductionRelease</a></code> | The production release workflow, if enabled. |
@@ -1657,6 +1974,18 @@ public readonly workspaceFile: YamlFile;
 - *Type:* projen.YamlFile
 
 The generated `pnpm-workspace.yaml`.
+
+---
+
+##### `amplifyDeploy`<sup>Optional</sup> <a name="amplifyDeploy" id="@taimos/projen.MonorepoProject.property.amplifyDeploy"></a>
+
+```typescript
+public readonly amplifyDeploy: GitHubAmplifyDeploy;
+```
+
+- *Type:* <a href="#@taimos/projen.GitHubAmplifyDeploy">GitHubAmplifyDeploy</a>
+
+The Amplify deploy workflows, when `amplifyDeployOptions` is set.
 
 ---
 
@@ -10316,6 +10645,321 @@ public readonly DEFAULT_TS_JEST_TRANFORM_PATTERN: string;
 
 ## Structs <a name="Structs" id="Structs"></a>
 
+### AmplifyDeployApp <a name="AmplifyDeployApp" id="@taimos/projen.AmplifyDeployApp"></a>
+
+One Amplify Hosting application whose builds CI drives.
+
+Mirrors a `MonorepoAmplifyApp` entry in the generated `amplify.yml`; the
+`appRoot` should match so a build is triggered by exactly the directory it is
+built from.
+
+#### Initializer <a name="Initializer" id="@taimos/projen.AmplifyDeployApp.Initializer"></a>
+
+```typescript
+import { AmplifyDeployApp } from '@taimos/projen'
+
+const amplifyDeployApp: AmplifyDeployApp = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@taimos/projen.AmplifyDeployApp.property.appRoot">appRoot</a></code> | <code>string</code> | The package path that is the Amplify app root, e.g. `packages/frontend`. `<appRoot>/**` becomes a push trigger path. |
+| <code><a href="#@taimos/projen.AmplifyDeployApp.property.key">key</a></code> | <code>string</code> | Short key identifying the app. Used in the app-id SSM parameter path and, by default, in the workflow name. |
+| <code><a href="#@taimos/projen.AmplifyDeployApp.property.dependencyPaths">dependencyPaths</a></code> | <code>string[]</code> | Extra path globs that affect this app's build output. |
+| <code><a href="#@taimos/projen.AmplifyDeployApp.property.label">label</a></code> | <code>string</code> | Human-readable name used in step names and log lines. |
+| <code><a href="#@taimos/projen.AmplifyDeployApp.property.workflowName">workflowName</a></code> | <code>string</code> | The generated workflow name, which is also its `.yml` file name. |
+
+---
+
+##### `appRoot`<sup>Required</sup> <a name="appRoot" id="@taimos/projen.AmplifyDeployApp.property.appRoot"></a>
+
+```typescript
+public readonly appRoot: string;
+```
+
+- *Type:* string
+
+The package path that is the Amplify app root, e.g. `packages/frontend`. `<appRoot>/**` becomes a push trigger path.
+
+---
+
+##### `key`<sup>Required</sup> <a name="key" id="@taimos/projen.AmplifyDeployApp.property.key"></a>
+
+```typescript
+public readonly key: string;
+```
+
+- *Type:* string
+
+Short key identifying the app. Used in the app-id SSM parameter path and, by default, in the workflow name.
+
+Must match the key the CDK side registers the app under.
+
+---
+
+##### `dependencyPaths`<sup>Optional</sup> <a name="dependencyPaths" id="@taimos/projen.AmplifyDeployApp.property.dependencyPaths"></a>
+
+```typescript
+public readonly dependencyPaths: string[];
+```
+
+- *Type:* string[]
+- *Default:* []
+
+Extra path globs that affect this app's build output.
+
+Set this for workspace packages the app consumes via `workspace:*` and that
+the build spec pre-builds — a shared API package, say. Without them a change
+to shared types would not rebuild the app and it would ship stale.
+
+---
+
+##### `label`<sup>Optional</sup> <a name="label" id="@taimos/projen.AmplifyDeployApp.property.label"></a>
+
+```typescript
+public readonly label: string;
+```
+
+- *Type:* string
+- *Default:* the `key`
+
+Human-readable name used in step names and log lines.
+
+---
+
+##### `workflowName`<sup>Optional</sup> <a name="workflowName" id="@taimos/projen.AmplifyDeployApp.property.workflowName"></a>
+
+```typescript
+public readonly workflowName: string;
+```
+
+- *Type:* string
+- *Default:* `<key>-deploy`
+
+The generated workflow name, which is also its `.yml` file name.
+
+---
+
+### AmplifyDeployStage <a name="AmplifyDeployStage" id="@taimos/projen.AmplifyDeployStage"></a>
+
+One deploy stage: a git branch, the logical stage it serves, and the AWS account its Amplify apps live in.
+
+Both shapes seen in practice are expressible: separate accounts per stage
+(each entry has its own `account`), or a single account serving several
+branches (every entry repeats the same `account`, and the branch alone
+selects which Amplify branch is built).
+
+#### Initializer <a name="Initializer" id="@taimos/projen.AmplifyDeployStage.Initializer"></a>
+
+```typescript
+import { AmplifyDeployStage } from '@taimos/projen'
+
+const amplifyDeployStage: AmplifyDeployStage = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@taimos/projen.AmplifyDeployStage.property.account">account</a></code> | <code>string</code> | The AWS account hosting this stage's Amplify apps. |
+| <code><a href="#@taimos/projen.AmplifyDeployStage.property.branch">branch</a></code> | <code>string</code> | The git branch the Amplify apps build from, e.g. `main` or `production`. |
+| <code><a href="#@taimos/projen.AmplifyDeployStage.property.stageName">stageName</a></code> | <code>string</code> | The logical stage this branch serves, e.g. `dev` or `prod`. Used as the GitHub environment so protection rules apply per stage. |
+
+---
+
+##### `account`<sup>Required</sup> <a name="account" id="@taimos/projen.AmplifyDeployStage.property.account"></a>
+
+```typescript
+public readonly account: string;
+```
+
+- *Type:* string
+
+The AWS account hosting this stage's Amplify apps.
+
+---
+
+##### `branch`<sup>Required</sup> <a name="branch" id="@taimos/projen.AmplifyDeployStage.property.branch"></a>
+
+```typescript
+public readonly branch: string;
+```
+
+- *Type:* string
+
+The git branch the Amplify apps build from, e.g. `main` or `production`.
+
+---
+
+##### `stageName`<sup>Required</sup> <a name="stageName" id="@taimos/projen.AmplifyDeployStage.property.stageName"></a>
+
+```typescript
+public readonly stageName: string;
+```
+
+- *Type:* string
+
+The logical stage this branch serves, e.g. `dev` or `prod`. Used as the GitHub environment so protection rules apply per stage.
+
+---
+
+### GitHubAmplifyDeployOptions <a name="GitHubAmplifyDeployOptions" id="@taimos/projen.GitHubAmplifyDeployOptions"></a>
+
+#### Initializer <a name="Initializer" id="@taimos/projen.GitHubAmplifyDeployOptions.Initializer"></a>
+
+```typescript
+import { GitHubAmplifyDeployOptions } from '@taimos/projen'
+
+const gitHubAmplifyDeployOptions: GitHubAmplifyDeployOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.apps">apps</a></code> | <code><a href="#@taimos/projen.AmplifyDeployApp">AmplifyDeployApp</a>[]</code> | The Amplify apps to generate deploy workflows for. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.deploymentRoleArn">deploymentRoleArn</a></code> | <code>string</code> | The GitHub OIDC deployment role every workflow assumes first, typically in a management account. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.stages">stages</a></code> | <code><a href="#@taimos/projen.AmplifyDeployStage">AmplifyDeployStage</a>[]</code> | The branches that deploy, and the account each one deploys into. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.buildTriggerRoleName">buildTriggerRoleName</a></code> | <code>string</code> | Name of the per-account IAM role CI chains into to start builds. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.parameterPrefix">parameterPrefix</a></code> | <code>string</code> | Prefix of the SSM parameter path holding each app's Amplify app id. The full path is `<prefix>/<app key>/app-id`. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.region">region</a></code> | <code>string</code> | The AWS region the Amplify apps live in. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.runnerTags">runnerTags</a></code> | <code>string[]</code> | The runner tags used to select the runner. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.sharedBuildPaths">sharedBuildPaths</a></code> | <code>string[]</code> | Paths that change what *every* Amplify build produces, added to each app's own paths. |
+| <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions.property.timeoutMinutes">timeoutMinutes</a></code> | <code>number</code> | Timeout for a deploy job, bounding a hung Amplify build. |
+
+---
+
+##### `apps`<sup>Required</sup> <a name="apps" id="@taimos/projen.GitHubAmplifyDeployOptions.property.apps"></a>
+
+```typescript
+public readonly apps: AmplifyDeployApp[];
+```
+
+- *Type:* <a href="#@taimos/projen.AmplifyDeployApp">AmplifyDeployApp</a>[]
+
+The Amplify apps to generate deploy workflows for.
+
+At least one.
+
+---
+
+##### `deploymentRoleArn`<sup>Required</sup> <a name="deploymentRoleArn" id="@taimos/projen.GitHubAmplifyDeployOptions.property.deploymentRoleArn"></a>
+
+```typescript
+public readonly deploymentRoleArn: string;
+```
+
+- *Type:* string
+
+The GitHub OIDC deployment role every workflow assumes first, typically in a management account.
+
+The per-stage build-trigger role is reached from it
+by role chaining, so it must be allowed to `sts:AssumeRole` on that role —
+an IAM grant that lives outside the generated code.
+
+---
+
+##### `stages`<sup>Required</sup> <a name="stages" id="@taimos/projen.GitHubAmplifyDeployOptions.property.stages"></a>
+
+```typescript
+public readonly stages: AmplifyDeployStage[];
+```
+
+- *Type:* <a href="#@taimos/projen.AmplifyDeployStage">AmplifyDeployStage</a>[]
+
+The branches that deploy, and the account each one deploys into.
+
+At least one.
+
+---
+
+##### `buildTriggerRoleName`<sup>Optional</sup> <a name="buildTriggerRoleName" id="@taimos/projen.GitHubAmplifyDeployOptions.property.buildTriggerRoleName"></a>
+
+```typescript
+public readonly buildTriggerRoleName: string;
+```
+
+- *Type:* string
+- *Default:* `<project name>-amplify-build-trigger`
+
+Name of the per-account IAM role CI chains into to start builds.
+
+The same name is expected in every stage account, so the workflow can build
+the ARN from the account id alone. The CDK side must create a role with
+exactly this name.
+
+---
+
+##### `parameterPrefix`<sup>Optional</sup> <a name="parameterPrefix" id="@taimos/projen.GitHubAmplifyDeployOptions.property.parameterPrefix"></a>
+
+```typescript
+public readonly parameterPrefix: string;
+```
+
+- *Type:* string
+- *Default:* `/<project name>/amplify`
+
+Prefix of the SSM parameter path holding each app's Amplify app id. The full path is `<prefix>/<app key>/app-id`.
+
+Reading the app id at run time means CI never hardcodes an id that changes
+whenever an app is replaced.
+
+---
+
+##### `region`<sup>Optional</sup> <a name="region" id="@taimos/projen.GitHubAmplifyDeployOptions.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+- *Default:* 'eu-central-1'
+
+The AWS region the Amplify apps live in.
+
+---
+
+##### `runnerTags`<sup>Optional</sup> <a name="runnerTags" id="@taimos/projen.GitHubAmplifyDeployOptions.property.runnerTags"></a>
+
+```typescript
+public readonly runnerTags: string[];
+```
+
+- *Type:* string[]
+- *Default:* ['ubuntu-latest']
+
+The runner tags used to select the runner.
+
+---
+
+##### `sharedBuildPaths`<sup>Optional</sup> <a name="sharedBuildPaths" id="@taimos/projen.GitHubAmplifyDeployOptions.property.sharedBuildPaths"></a>
+
+```typescript
+public readonly sharedBuildPaths: string[];
+```
+
+- *Type:* string[]
+- *Default:* the Amplify build spec, the lockfile and the workspace file
+
+Paths that change what *every* Amplify build produces, added to each app's own paths.
+
+---
+
+##### `timeoutMinutes`<sup>Optional</sup> <a name="timeoutMinutes" id="@taimos/projen.GitHubAmplifyDeployOptions.property.timeoutMinutes"></a>
+
+```typescript
+public readonly timeoutMinutes: number;
+```
+
+- *Type:* number
+- *Default:* 45
+
+Timeout for a deploy job, bounding a hung Amplify build.
+
+---
+
 ### GitHubProductionReleaseOptions <a name="GitHubProductionReleaseOptions" id="@taimos/projen.GitHubProductionReleaseOptions"></a>
 
 #### Initializer <a name="Initializer" id="@taimos/projen.GitHubProductionReleaseOptions.Initializer"></a>
@@ -10750,6 +11394,7 @@ const monorepoProjectOptions: MonorepoProjectOptions = { ... }
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.amplifyApps">amplifyApps</a></code> | <code><a href="#@taimos/projen.MonorepoAmplifyApp">MonorepoAmplifyApp</a>[]</code> | AWS Amplify Hosting applications. |
+| <code><a href="#@taimos/projen.MonorepoProjectOptions.property.amplifyDeployOptions">amplifyDeployOptions</a></code> | <code><a href="#@taimos/projen.GitHubAmplifyDeployOptions">GitHubAmplifyDeployOptions</a></code> | Drive Amplify Hosting builds from GitHub Actions instead of Amplify's own auto-build, so an app only rebuilds when the packages it is built from actually changed (see `GitHubAmplifyDeploy`). |
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.approverMapping">approverMapping</a></code> | <code><a href="#@taimos/projen.MonorepoApproverMapping">MonorepoApproverMapping</a>[]</code> | Author-to-approvers routing for the PR approver assignment. |
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.assignApprover">assignApprover</a></code> | <code>boolean</code> | Whether to assign PR approvers via `GitHubAssignApprover`. |
 | <code><a href="#@taimos/projen.MonorepoProjectOptions.property.cdkServerless">cdkServerless</a></code> | <code>boolean</code> | Whether to add `cdk-serverless` as a workspace dev dependency. |
@@ -12960,6 +13605,23 @@ AWS Amplify Hosting applications.
 
 When set, an `amplify.yml` is generated
 with one entry per app. When omitted, no `amplify.yml` is created.
+
+---
+
+##### `amplifyDeployOptions`<sup>Optional</sup> <a name="amplifyDeployOptions" id="@taimos/projen.MonorepoProjectOptions.property.amplifyDeployOptions"></a>
+
+```typescript
+public readonly amplifyDeployOptions: GitHubAmplifyDeployOptions;
+```
+
+- *Type:* <a href="#@taimos/projen.GitHubAmplifyDeployOptions">GitHubAmplifyDeployOptions</a>
+- *Default:* Amplify's own auto-build is left in place
+
+Drive Amplify Hosting builds from GitHub Actions instead of Amplify's own auto-build, so an app only rebuilds when the packages it is built from actually changed (see `GitHubAmplifyDeploy`).
+
+Setting this generates one deploy workflow per listed app. The project's
+CDK app must disable `autoBuild` on the tracked branches and provide the
+app-id parameters and build-trigger role the workflows expect.
 
 ---
 

--- a/src/components/amplify-deploy.ts
+++ b/src/components/amplify-deploy.ts
@@ -1,0 +1,400 @@
+import { Component, github } from 'projen';
+import { GitHubProject } from 'projen/lib/github';
+
+/**
+ * One deploy stage: a git branch, the logical stage it serves, and the AWS
+ * account its Amplify apps live in.
+ *
+ * Both shapes seen in practice are expressible: separate accounts per stage
+ * (each entry has its own `account`), or a single account serving several
+ * branches (every entry repeats the same `account`, and the branch alone
+ * selects which Amplify branch is built).
+ */
+export interface AmplifyDeployStage {
+  /** The git branch the Amplify apps build from, e.g. `main` or `production`. */
+  readonly branch: string;
+
+  /**
+   * The logical stage this branch serves, e.g. `dev` or `prod`. Used as the
+   * GitHub environment so protection rules apply per stage.
+   */
+  readonly stageName: string;
+
+  /** The AWS account hosting this stage's Amplify apps. */
+  readonly account: string;
+}
+
+/**
+ * One Amplify Hosting application whose builds CI drives.
+ *
+ * Mirrors a `MonorepoAmplifyApp` entry in the generated `amplify.yml`; the
+ * `appRoot` should match so a build is triggered by exactly the directory it is
+ * built from.
+ */
+export interface AmplifyDeployApp {
+  /**
+   * Short key identifying the app. Used in the app-id SSM parameter path and,
+   * by default, in the workflow name.
+   *
+   * Must match the key the CDK side registers the app under.
+   */
+  readonly key: string;
+
+  /**
+   * The package path that is the Amplify app root, e.g. `packages/frontend`.
+   * `<appRoot>/**` becomes a push trigger path.
+   */
+  readonly appRoot: string;
+
+  /**
+   * Extra path globs that affect this app's build output.
+   *
+   * Set this for workspace packages the app consumes via `workspace:*` and that
+   * the build spec pre-builds — a shared API package, say. Without them a change
+   * to shared types would not rebuild the app and it would ship stale.
+   *
+   * @default []
+   */
+  readonly dependencyPaths?: string[];
+
+  /**
+   * Human-readable name used in step names and log lines.
+   *
+   * @default - the `key`
+   */
+  readonly label?: string;
+
+  /**
+   * The generated workflow name, which is also its `.yml` file name.
+   *
+   * @default - `<key>-deploy`
+   */
+  readonly workflowName?: string;
+}
+
+export interface GitHubAmplifyDeployOptions {
+  /** The Amplify apps to generate deploy workflows for. At least one. */
+  readonly apps: AmplifyDeployApp[];
+
+  /** The branches that deploy, and the account each one deploys into. At least one. */
+  readonly stages: AmplifyDeployStage[];
+
+  /**
+   * The GitHub OIDC deployment role every workflow assumes first, typically in
+   * a management account. The per-stage build-trigger role is reached from it
+   * by role chaining, so it must be allowed to `sts:AssumeRole` on that role —
+   * an IAM grant that lives outside the generated code.
+   */
+  readonly deploymentRoleArn: string;
+
+  /**
+   * Name of the per-account IAM role CI chains into to start builds.
+   *
+   * The same name is expected in every stage account, so the workflow can build
+   * the ARN from the account id alone. The CDK side must create a role with
+   * exactly this name.
+   *
+   * @default - `<project name>-amplify-build-trigger`
+   */
+  readonly buildTriggerRoleName?: string;
+
+  /**
+   * Prefix of the SSM parameter path holding each app's Amplify app id. The
+   * full path is `<prefix>/<app key>/app-id`.
+   *
+   * Reading the app id at run time means CI never hardcodes an id that changes
+   * whenever an app is replaced.
+   *
+   * @default - `/<project name>/amplify`
+   */
+  readonly parameterPrefix?: string;
+
+  /**
+   * The AWS region the Amplify apps live in.
+   *
+   * @default 'eu-central-1'
+   */
+  readonly region?: string;
+
+  /**
+   * Paths that change what *every* Amplify build produces, added to each app's
+   * own paths.
+   *
+   * @default - the Amplify build spec, the lockfile and the workspace file
+   */
+  readonly sharedBuildPaths?: string[];
+
+  /**
+   * The runner tags used to select the runner.
+   *
+   * @default ['ubuntu-latest']
+   */
+  readonly runnerTags?: string[];
+
+  /**
+   * Timeout for a deploy job, bounding a hung Amplify build.
+   *
+   * @default 45
+   */
+  readonly timeoutMinutes?: number;
+}
+
+/** Paths that invalidate every app's build output. */
+const DEFAULT_SHARED_BUILD_PATHS = [
+  'amplify.yml',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+];
+
+/**
+ * Adds one path-scoped deploy workflow per Amplify Hosting app.
+ *
+ * Amplify's own auto-build fires on every push to a tracked branch. In a
+ * monorepo that means every frontend rebuilds whenever anything changes — the
+ * marketing site rebuilding for a backend-only commit and vice versa, once per
+ * tracked branch. Amplify bills build minutes, so most of those are waste.
+ *
+ * Amplify's native answer, `AMPLIFY_DIFF_DEPLOY`, diffs exactly one directory
+ * (`AMPLIFY_MONOREPO_APP_ROOT`, overridable via `AMPLIFY_DIFF_DEPLOY_ROOT` —
+ * still a single path). That is enough for a self-contained app but not for one
+ * that also depends on a shared workspace package: a one-directory diff would
+ * ship a stale frontend whenever the shared types changed. GitHub's `paths:`
+ * filters accept multiple globs, so builds move to CI.
+ *
+ * Each generated workflow resolves the pushed branch to its stage and account,
+ * chains OIDC -> deployment role -> build-trigger role, reads the app id from
+ * SSM, starts a `RELEASE` job and polls until it reaches a terminal state — so
+ * a failed Amplify build fails the workflow instead of passing silently.
+ *
+ * This component generates the CI half only. The infrastructure half belongs in
+ * the project's own CDK app, which must:
+ *
+ *   1. set `autoBuild: false` on every branch these workflows build,
+ *   2. publish each app's id to `<parameterPrefix>/<key>/app-id`, and
+ *   3. create a role named `buildTriggerRoleName` in each stage account,
+ *      trusted by `deploymentRoleArn` and granting `amplify:StartJob` +
+ *      `amplify:GetJob` on the tracked branch ARNs only.
+ *
+ * Use `buildTriggerRoleName` and `appIdParameterName()` from the projenrc to
+ * keep those names in step; a mismatch fails the workflow loudly at the
+ * assume-role or parameter-read step rather than skipping a deploy.
+ */
+export class GitHubAmplifyDeploy extends Component {
+  /** The generated deploy workflows, one per app. */
+  public readonly workflows: github.GithubWorkflow[] = [];
+
+  /** Name of the IAM role CI chains into, in every stage account. */
+  public readonly buildTriggerRoleName: string;
+
+  /** Prefix of the SSM parameter path holding each app's Amplify app id. */
+  public readonly parameterPrefix: string;
+
+  private readonly region: string;
+
+  constructor(scope: GitHubProject, options: GitHubAmplifyDeployOptions) {
+    super(scope);
+
+    if (!scope.github) {
+      throw new Error('GitHubAmplifyDeploy requires a project with GitHub enabled');
+    }
+    if (options.apps.length === 0) {
+      throw new Error('GitHubAmplifyDeploy requires at least one app');
+    }
+    if (options.stages.length === 0) {
+      throw new Error('GitHubAmplifyDeploy requires at least one stage');
+    }
+
+    const keys = options.apps.map((app) => app.key);
+    const duplicateKey = keys.find((key, index) => keys.indexOf(key) !== index);
+    if (duplicateKey) {
+      throw new Error(`GitHubAmplifyDeploy app keys must be unique, got '${duplicateKey}' twice`);
+    }
+
+    const branches = options.stages.map((stage) => stage.branch);
+    const duplicateBranch = branches.find((branch, index) => branches.indexOf(branch) !== index);
+    if (duplicateBranch) {
+      throw new Error(`GitHubAmplifyDeploy stage branches must be unique, got '${duplicateBranch}' twice`);
+    }
+
+    this.buildTriggerRoleName = options.buildTriggerRoleName ?? `${scope.name}-amplify-build-trigger`;
+    this.parameterPrefix = options.parameterPrefix ?? `/${scope.name}/amplify`;
+    this.region = options.region ?? 'eu-central-1';
+
+    const sharedBuildPaths = options.sharedBuildPaths ?? DEFAULT_SHARED_BUILD_PATHS;
+    const runnerTags = options.runnerTags ?? ['ubuntu-latest'];
+    const timeoutMinutes = options.timeoutMinutes ?? 45;
+
+    for (const app of options.apps) {
+      const label = app.label ?? app.key;
+      const workflowName = app.workflowName ?? `${app.key}-deploy`;
+
+      const workflow = new github.GithubWorkflow(scope.github, workflowName);
+      workflow.on({
+        push: {
+          branches: options.stages.map((stage) => stage.branch),
+          paths: [
+            `${app.appRoot}/**`,
+            ...(app.dependencyPaths ?? []),
+            ...sharedBuildPaths,
+            // Changing the workflow itself should prove it still works.
+            `.github/workflows/${workflowName}.yml`,
+          ],
+        },
+        // Manual redeploy, e.g. after a build-only failure.
+        workflowDispatch: {},
+      });
+
+      workflow.addJob('deploy', {
+        name: `Build and deploy the ${label} on Amplify`,
+        runsOn: runnerTags,
+        permissions: {
+          contents: github.workflows.JobPermission.READ,
+          idToken: github.workflows.JobPermission.WRITE,
+        },
+        environment: this.environmentExpression(options.stages),
+        concurrency: {
+          'group': `${workflowName}-\${{ github.ref_name }}`,
+          // Cancelling the workflow would not cancel the Amplify job it started,
+          // so let runs queue instead of orphaning builds.
+          'cancel-in-progress': false,
+        },
+        timeoutMinutes,
+        steps: [
+          {
+            name: 'Resolve stage',
+            id: 'stage',
+            run: this.resolveStageScript(options.stages),
+          },
+          {
+            name: 'AWS credentials — deployment role',
+            id: 'aws_credentials_deployment_role',
+            uses: 'aws-actions/configure-aws-credentials@v5',
+            with: {
+              'role-to-assume': options.deploymentRoleArn,
+              'role-session-name': 'GitHubAction',
+              'aws-region': this.region,
+            },
+          },
+          {
+            name: 'AWS credentials — Amplify build trigger',
+            id: 'aws_credentials_amplify_build_trigger',
+            uses: 'aws-actions/configure-aws-credentials@v5',
+            with: {
+              'role-to-assume': '${{ steps.stage.outputs.role_arn }}',
+              'role-session-name': 'AmplifyBuildTrigger',
+              'aws-region': this.region,
+              // Chain from the deployment role rather than re-using the OIDC
+              // token, so no identity provider is needed in the stage account.
+              'role-chaining': true,
+              // The action tags sessions by default, which turns the chained
+              // call into AssumeRole + TagSession. The trust policy grants
+              // AssumeRole only, so tagging fails the step; the session is
+              // already tagged by the first assume anyway.
+              'role-skip-session-tagging': true,
+            },
+          },
+          {
+            name: `Start ${label} build`,
+            id: 'start',
+            run: this.startBuildScript(app, label),
+          },
+          {
+            name: 'Wait for build to finish',
+            id: 'wait_for_build_to_finish',
+            run: this.waitForBuildScript(label),
+          },
+        ],
+      });
+
+      this.workflows.push(workflow);
+    }
+  }
+
+  /**
+   * The SSM parameter path holding an app's Amplify app id. The CDK side must
+   * publish the id under exactly this name.
+   */
+  public appIdParameterName(key: string): string {
+    return `${this.parameterPrefix}/${key}/app-id`;
+  }
+
+  /**
+   * The job-level `environment:` expression mapping branch to stage, so each
+   * stage keeps whatever GitHub environment protection rules it has. The first
+   * stage is the fallback; every later stage gets an explicit branch test.
+   */
+  private environmentExpression(stages: AmplifyDeployStage[]): string {
+    const [fallback, ...rest] = stages;
+    const tests = rest.map((s) => `github.ref_name == '${s.branch}' && '${s.stageName}' || `).join('');
+    return `\${{ ${tests}'${fallback.stageName}' }}`;
+  }
+
+  /**
+   * Bash mapping the pushed branch to its stage and build-trigger role ARN, so
+   * account ids live only in the projenrc. A branch that is not a deploy branch
+   * is an error rather than a silent no-op.
+   */
+  private resolveStageScript(stages: AmplifyDeployStage[]): string {
+    const cases = stages.map((s) => `  ${s.branch}) stage='${s.stageName}'; account='${s.account}' ;;`);
+    return [
+      'set -euo pipefail',
+      'case "$GITHUB_REF_NAME" in',
+      ...cases,
+      '  *)',
+      '    echo "::error::$GITHUB_REF_NAME is not a deploy branch"',
+      '    exit 1',
+      '    ;;',
+      'esac',
+      `role="arn:aws:iam::$account:role/${this.buildTriggerRoleName}"`,
+      'echo "stage=$stage" >> "$GITHUB_OUTPUT"',
+      'echo "role_arn=$role" >> "$GITHUB_OUTPUT"',
+      'echo "Deploying $GITHUB_REF_NAME to stage $stage ($account)" >> "$GITHUB_STEP_SUMMARY"',
+    ].join('\n');
+  }
+
+  /** Reads the app id from SSM and starts a RELEASE build. */
+  private startBuildScript(app: AmplifyDeployApp, label: string): string {
+    return [
+      'set -euo pipefail',
+      `app_id="$(aws ssm get-parameter --name '${this.appIdParameterName(app.key)}' --query Parameter.Value --output text)"`,
+      '# RELEASE builds the current tip of the branch. That is normally $GITHUB_SHA;',
+      '# if two pushes race, the tip wins and the earlier run is redundant rather',
+      '# than wrong. The job concurrency group keeps that rare.',
+      'job_id="$(aws amplify start-job \\',
+      '  --app-id "$app_id" \\',
+      '  --branch-name "$GITHUB_REF_NAME" \\',
+      '  --job-type RELEASE \\',
+      '  --job-reason "GitHub Actions $GITHUB_WORKFLOW run $GITHUB_RUN_ID for $GITHUB_SHA" \\',
+      '  --query jobSummary.jobId --output text)"',
+      'echo "app_id=$app_id" >> "$GITHUB_OUTPUT"',
+      'echo "job_id=$job_id" >> "$GITHUB_OUTPUT"',
+      `echo "Started ${label} Amplify job \$job_id on app \$app_id" >> "\$GITHUB_STEP_SUMMARY"`,
+    ].join('\n');
+  }
+
+  /** Polls the job until it reaches a terminal state, failing on a bad one. */
+  private waitForBuildScript(label: string): string {
+    return [
+      'set -euo pipefail',
+      'while true; do',
+      '  status="$(aws amplify get-job \\',
+      '    --app-id "${{ steps.start.outputs.app_id }}" \\',
+      '    --branch-name "$GITHUB_REF_NAME" \\',
+      '    --job-id "${{ steps.start.outputs.job_id }}" \\',
+      '    --query job.summary.status --output text)"',
+      '  case "$status" in',
+      '    SUCCEED)',
+      `      echo "${label} build succeeded" >> "\$GITHUB_STEP_SUMMARY"`,
+      '      exit 0',
+      '      ;;',
+      '    FAILED|CANCELLED)',
+      `      echo "::error::${label} Amplify job \${{ steps.start.outputs.job_id }} ended as \$status"`,
+      '      exit 1',
+      '      ;;',
+      '  esac',
+      '  echo "status: $status"',
+      '  sleep 15',
+      'done',
+    ].join('\n');
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
+export * from './amplify-deploy';
 export * from './production-release';

--- a/src/projects/monorepo.ts
+++ b/src/projects/monorepo.ts
@@ -1,6 +1,6 @@
 import { github, javascript, typescript, YamlFile } from 'projen';
 import { GitHubAssignApprover } from 'projen-pipelines';
-import { GitHubProductionRelease, GitHubProductionReleaseOptions } from '../components';
+import { GitHubAmplifyDeploy, GitHubAmplifyDeployOptions, GitHubProductionRelease, GitHubProductionReleaseOptions } from '../components';
 
 /**
  * The frontend framework an Amplify Hosting application is built with.
@@ -237,6 +237,19 @@ export interface MonorepoProjectOptions extends typescript.TypeScriptProjectOpti
    * @default - promote `main` to a `production` branch
    */
   readonly productionReleaseOptions?: GitHubProductionReleaseOptions;
+
+  /**
+   * Drive Amplify Hosting builds from GitHub Actions instead of Amplify's own
+   * auto-build, so an app only rebuilds when the packages it is built from
+   * actually changed (see `GitHubAmplifyDeploy`).
+   *
+   * Setting this generates one deploy workflow per listed app. The project's
+   * CDK app must disable `autoBuild` on the tracked branches and provide the
+   * app-id parameters and build-trigger role the workflows expect.
+   *
+   * @default - Amplify's own auto-build is left in place
+   */
+  readonly amplifyDeployOptions?: GitHubAmplifyDeployOptions;
 }
 
 /**
@@ -268,6 +281,9 @@ export class MonorepoProject extends typescript.TypeScriptProject {
 
   /** The production release workflow, if enabled. */
   public readonly productionRelease?: GitHubProductionRelease;
+
+  /** The Amplify deploy workflows, when `amplifyDeployOptions` is set. */
+  public readonly amplifyDeploy?: GitHubAmplifyDeploy;
 
   /** The default release branch (promoted by the production release workflow). */
   public readonly defaultReleaseBranch: string;
@@ -365,6 +381,10 @@ export class MonorepoProject extends typescript.TypeScriptProject {
     }
 
     // Manual production release — promotes a branch to the production branch.
+    if (options.amplifyDeployOptions) {
+      this.amplifyDeploy = new GitHubAmplifyDeploy(this, options.amplifyDeployOptions);
+    }
+
     if (options.productionRelease ?? false) {
       this.productionRelease = new GitHubProductionRelease(this, options.productionReleaseOptions);
     }

--- a/test/amplify-deploy.test.ts
+++ b/test/amplify-deploy.test.ts
@@ -1,0 +1,169 @@
+import { Testing } from 'projen';
+import * as yaml from 'yaml';
+import { AmplifyDeployApp, AmplifyDeployStage, GitHubAmplifyDeployOptions, MonorepoProject, MonorepoProjectOptions } from '../src';
+
+const STAGES: AmplifyDeployStage[] = [
+  { branch: 'main', stageName: 'dev', account: '111111111111' },
+  { branch: 'production', stageName: 'prod', account: '222222222222' },
+];
+
+const PORTAL: AmplifyDeployApp = {
+  key: 'portal',
+  appRoot: 'packages/portal',
+  dependencyPaths: ['packages/api/**'],
+};
+
+const DOCS: AmplifyDeployApp = { key: 'docs', appRoot: 'packages/docs' };
+
+const DEPLOYMENT_ROLE_ARN = 'arn:aws:iam::999999999999:role/GitHubDeployment-test-main';
+
+function synthMonorepo(opts: Partial<MonorepoProjectOptions> = {}) {
+  const project = new MonorepoProject({
+    name: 'test-monorepo',
+    defaultReleaseBranch: 'main',
+    ...opts,
+  });
+  return Testing.synth(project) as Record<string, any>;
+}
+
+function synthDeploy(options: Partial<GitHubAmplifyDeployOptions> = {}) {
+  return synthMonorepo({
+    amplifyDeployOptions: {
+      apps: [PORTAL, DOCS],
+      stages: STAGES,
+      deploymentRoleArn: DEPLOYMENT_ROLE_ARN,
+      ...options,
+    },
+  });
+}
+
+describe('GitHubAmplifyDeploy', () => {
+  test('is opt-in: no workflows by default', () => {
+    const out = synthMonorepo();
+    expect(out['.github/workflows/portal-deploy.yml']).toBeUndefined();
+  });
+
+  test('generates one workflow per app, named <key>-deploy', () => {
+    const out = synthDeploy();
+    expect(out['.github/workflows/portal-deploy.yml']).toBeDefined();
+    expect(out['.github/workflows/docs-deploy.yml']).toBeDefined();
+  });
+
+  test('triggers only on the app root, its dependencies and the shared build inputs', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+
+    expect(wf.on.push.branches).toEqual(['main', 'production']);
+    expect(wf.on.push.paths).toEqual([
+      'packages/portal/**',
+      'packages/api/**',
+      'amplify.yml',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      '.github/workflows/portal-deploy.yml',
+    ]);
+    // A manual redeploy after a build-only failure must not need a dummy commit.
+    expect(wf.on).toHaveProperty('workflow_dispatch');
+  });
+
+  test('an app without dependencies triggers on its own root only', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/docs-deploy.yml']);
+    expect(wf.on.push.paths).not.toContain('packages/api/**');
+    expect(wf.on.push.paths).toContain('packages/docs/**');
+  });
+
+  test('maps each branch to its stage and account, and rejects any other branch', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    const resolve = wf.jobs.deploy.steps.find((s: any) => s.id === 'stage').run;
+
+    expect(resolve).toContain("main) stage='dev'; account='111111111111'");
+    expect(resolve).toContain("production) stage='prod'; account='222222222222'");
+    expect(resolve).toContain('arn:aws:iam::$account:role/test-monorepo-amplify-build-trigger');
+    // An unexpected branch fails loudly rather than deploying somewhere random.
+    expect(resolve).toContain('is not a deploy branch');
+  });
+
+  test('uses the per-stage GitHub environment so protection rules apply', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    expect(wf.jobs.deploy.environment).toBe(
+      "${{ github.ref_name == 'production' && 'prod' || 'dev' }}",
+    );
+  });
+
+  test('chains the deployment role into the build-trigger role without session tagging', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    const steps = wf.jobs.deploy.steps;
+
+    const first = steps.find((s: any) => s.id === 'aws_credentials_deployment_role');
+    expect(first.with['role-to-assume']).toBe(DEPLOYMENT_ROLE_ARN);
+    expect(first.with).not.toHaveProperty('role-chaining');
+
+    const second = steps.find((s: any) => s.id === 'aws_credentials_amplify_build_trigger');
+    expect(second.with['role-to-assume']).toBe('${{ steps.stage.outputs.role_arn }}');
+    expect(second.with['role-chaining']).toBe(true);
+    // The trust policy grants AssumeRole only; tagging would turn the chained
+    // call into AssumeRole + TagSession and fail the step.
+    expect(second.with['role-skip-session-tagging']).toBe(true);
+  });
+
+  test('reads the app id from SSM rather than hardcoding it', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    const start = wf.jobs.deploy.steps.find((s: any) => s.id === 'start').run;
+
+    expect(start).toContain("aws ssm get-parameter --name '/test-monorepo/amplify/portal/app-id'");
+    expect(start).toContain('--job-type RELEASE');
+  });
+
+  test('fails the workflow when the Amplify build fails', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    const wait = wf.jobs.deploy.steps.find((s: any) => s.id === 'wait_for_build_to_finish').run;
+
+    expect(wait).toContain('aws amplify get-job');
+    expect(wait).toContain('FAILED|CANCELLED)');
+    expect(wait).toContain('exit 1');
+  });
+
+  test('queues concurrent runs instead of orphaning a started Amplify job', () => {
+    const wf = yaml.parse(synthDeploy()['.github/workflows/portal-deploy.yml']);
+    expect(wf.jobs.deploy.concurrency['cancel-in-progress']).toBe(false);
+    expect(wf.jobs.deploy['timeout-minutes']).toBe(45);
+  });
+
+  test('a single account serving several branches is expressible', () => {
+    const out = synthDeploy({
+      stages: [
+        { branch: 'main', stageName: 'dev', account: '111111111111' },
+        { branch: 'production', stageName: 'prod', account: '111111111111' },
+      ],
+    });
+    const resolve = yaml.parse(out['.github/workflows/portal-deploy.yml'])
+      .jobs.deploy.steps.find((s: any) => s.id === 'stage').run;
+
+    expect(resolve).toContain("main) stage='dev'; account='111111111111'");
+    expect(resolve).toContain("production) stage='prod'; account='111111111111'");
+  });
+
+  test('role name, parameter prefix, region and workflow name are overridable', () => {
+    const out = synthDeploy({
+      apps: [{ ...PORTAL, workflowName: 'frontend-release', label: 'frontend' }],
+      buildTriggerRoleName: 'custom-trigger',
+      parameterPrefix: '/custom/amplify',
+      region: 'us-east-1',
+    });
+    const wf = yaml.parse(out['.github/workflows/frontend-release.yml']);
+
+    expect(wf.jobs.deploy.name).toBe('Build and deploy the frontend on Amplify');
+    expect(wf.jobs.deploy.steps.find((s: any) => s.id === 'stage').run)
+      .toContain('role/custom-trigger');
+    expect(wf.jobs.deploy.steps.find((s: any) => s.id === 'start').run)
+      .toContain('/custom/amplify/portal/app-id');
+    expect(wf.jobs.deploy.steps.find((s: any) => s.id === 'aws_credentials_deployment_role').with['aws-region'])
+      .toBe('us-east-1');
+  });
+
+  test('rejects an empty or ambiguous configuration', () => {
+    expect(() => synthDeploy({ apps: [] })).toThrow(/at least one app/);
+    expect(() => synthDeploy({ stages: [] })).toThrow(/at least one stage/);
+    expect(() => synthDeploy({ apps: [PORTAL, PORTAL] })).toThrow(/app keys must be unique/);
+    expect(() => synthDeploy({ stages: [STAGES[0], STAGES[0]] })).toThrow(/branches must be unique/);
+  });
+});


### PR DESCRIPTION

## Why

Amplify's own auto-build fires on every push to a tracked branch. In a
PNPM-workspace monorepo that means every frontend rebuilds whenever anything
changes — the marketing site rebuilding for a backend-only commit and vice
versa, once per tracked branch. Amplify bills build minutes, and in the two
repos where this pattern has been deployed roughly half of all builds were
rebuilding a package that had not changed.

Amplify's native answer, `AMPLIFY_DIFF_DEPLOY`, diffs exactly one directory
(`AMPLIFY_MONOREPO_APP_ROOT`, overridable via `AMPLIFY_DIFF_DEPLOY_ROOT` — still
a single path). That is enough for a self-contained app but not for one that
also consumes a shared workspace package via `workspace:*` and whose build spec
pre-builds it: a one-directory diff would ship a stale frontend whenever the
shared API types changed. GitHub's `paths:` filters accept multiple globs, so
builds move to CI.

This generalises an implementation already running in two Taimos repos, which
differed only in configuration — account layout, naming and trigger paths.

## What changed

New `GitHubAmplifyDeploy` component in `src/components/amplify-deploy.ts`,
alongside `GitHubProductionRelease`, wired into `MonorepoProject` through a new
`amplifyDeployOptions` option.

It generates one deploy workflow per Amplify app. Each workflow:

- triggers on the app's own root, its declared dependency paths, the shared
  build inputs (`amplify.yml`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) and its
  own file, plus `workflow_dispatch` for a manual redeploy;
- resolves the pushed branch to its stage and account, failing loudly on a
  branch that is not a deploy branch;
- chains OIDC -> deployment role -> per-account build-trigger role
  (`role-chaining` with `role-skip-session-tagging`, since the trust policy
  grants `AssumeRole` only and the session is already tagged by the first
  assume);
- reads the app id from SSM rather than hardcoding an id that changes whenever
  an app is replaced;
- starts a `RELEASE` job and polls `GetJob` until terminal, so a failed Amplify
  build fails the workflow instead of passing silently.

Apps are described as `appRoot` plus optional `dependencyPaths`, mirroring
`MonorepoAmplifyApp.appRoot` in the same options object so the trigger path and
the build root cannot silently disagree. `dependencyPaths` names exactly the
case `AMPLIFY_DIFF_DEPLOY` cannot express.

Stages are `{ branch, stageName, account }`. Both deployed shapes are
expressible: a separate account per stage, or one account serving several
branches where the branch alone selects which Amplify branch is built.

Defaults derive from the project name — `<name>-amplify-build-trigger` and
`/<name>/amplify/<key>/app-id` — and role name, parameter prefix, region,
shared paths, runner tags, timeout and workflow name are all overridable.
Empty apps/stages and duplicate keys or branches are rejected at synth time.

## What is deliberately not here

The infrastructure half. `@taimos/projen` is a jsii library whose only
construct-ish dependency is `constructs` as a devDep; pulling in `aws-cdk-lib`
and `@aws-cdk/aws-amplify-alpha` to ship an L3 would be the wrong dependency
direction. Consuming projects keep their own CDK construct, which must:

1. set `autoBuild: false` on every branch these workflows build,
2. publish each app's id to `<parameterPrefix>/<key>/app-id`, and
3. create a role named `buildTriggerRoleName` in each stage account, trusted by
   the deployment role and granting `amplify:StartJob` + `amplify:GetJob` on the
   tracked branch ARNs only — never app-wide.

`buildTriggerRoleName` and `appIdParameterName()` are public so a projenrc can
reference the exact strings instead of retyping them. A mismatch fails the
workflow at the assume-role or parameter-read step rather than skipping a
deploy.

## Note for adopters

The deployment role needs `sts:AssumeRole` on the build-trigger role in each
stage account — an IAM grant outside the generated code. And the first run after
merge fails by construction: the new workflow files sit inside their own trigger
paths, so they fire on the merge commit before the role and parameters exist.
Let them fail, deploy the infra, then re-run via `workflow_dispatch`.

## Tests

`test/amplify-deploy.test.ts` covers the opt-in default, trigger paths with and
without dependencies, branch/stage/account mapping and the unknown-branch guard,
the GitHub environment expression, the two-step role chain, SSM app-id lookup,
build-failure propagation, concurrency and timeout, the single-account layout,
every override, and the four validation errors. `npx projen build` is green —
jsii compile, 31 tests, eslint, docgen.